### PR TITLE
Add scaffold for reservations model

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,0 +1,13 @@
+class Reservation < ApplicationRecord
+  # NOTE: Seems like a reservation should belong to both table and restaurant,
+  # as opposed to going through a nested association
+  belongs_to :table
+  belongs_to :restaurant
+
+  validates :owner_name, presence: true
+  validates :owner_phone_number, presence: true
+
+  validates :start_datetime, presence: true
+
+  # validate start_datetime is in the future, but only on create?
+end

--- a/db/migrate/20240303161633_create_reservations.rb
+++ b/db/migrate/20240303161633_create_reservations.rb
@@ -1,0 +1,15 @@
+class CreateReservations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :reservations do |t|
+      t.belongs_to :table
+      t.belongs_to :restaurant
+
+      t.string     :owner_name
+      t.string     :owner_phone_number
+
+      t.datetime   :start_datetime
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_03_155848) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_03_161633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "reservations", force: :cascade do |t|
+    t.bigint "table_id"
+    t.bigint "restaurant_id"
+    t.string "owner_name"
+    t.string "owner_phone_number"
+    t.datetime "start_datetime"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["restaurant_id"], name: "index_reservations_on_restaurant_id"
+    t.index ["table_id"], name: "index_reservations_on_table_id"
+  end
 
   create_table "restaurants", force: :cascade do |t|
     t.string "name"

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Reservation, type: :model do
+  context "associations" do
+    it { is_expected.to belong_to(:table) }
+    it { is_expected.to belong_to(:restaurant) }
+  end
+
+  context "validations" do
+    it { is_expected.to validate_presence_of(:owner_name) }
+    it { is_expected.to validate_presence_of(:owner_phone_number) }
+
+    it { is_expected.to validate_presence_of(:start_datetime) }
+  end
+end


### PR DESCRIPTION
Add migration, model, and spec for reservations. Add attributes for an owner name, owner phone number, and start datetime. Associate reservation to both table and restaurant.