### PR TITLE
Add /tables/occupied to get reserved tables from a datetime parameter

### DIFF
--- a/app/api/resources/table.rb
+++ b/app/api/resources/table.rb
@@ -34,6 +34,24 @@ module Resources
           present tables, with: ::API::Entities::Table
         end
 
+        desc 'Return a list of occupied tables given a past datetime'
+        params do
+          # build_with Grape::Extensions::Hash::ParamBuilder
+
+          requires :restaurant_id, type: Integer, allow_blank: false, desc: 'Restaurant ID'
+          requires :reservation_datetime, type: DateTime, allow_blank: false, desc: 'Past Reservation DateTime.'
+        end
+
+        get :occupied do
+          restaurant = ::Restaurant.find(params[:restaurant_id])
+
+          table_ids = restaurant.occupied_tables_at_datetime(params[:reservation_datetime]).union(restaurant.occupied_tables_at_datetime(params[:reservation_datetime] + 2.hours))
+
+          tables = ::Table.find(table_ids)
+
+          present tables, with: ::API::Entities::Table
+        end
+
         desc 'Return a table'
         params do
           requires :id, type: Integer, desc: 'Table ID.'

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -8,20 +8,22 @@ class Restaurant < ApplicationRecord
     tables.sum(:capacity)
   end
 
-  def guests_at_datetime(datetime)
+  def reservations_at_datetime(datetime)
     reservations.where(Reservation.arel_table[:start_datetime].lteq(datetime))
                 .where(Reservation.arel_table[:end_datetime].gteq(datetime))
                 .joins(reservation_tables: :table )
-                .sum(:capacity)
+  end
+
+  def guests_at_datetime(datetime)
+    reservations_at_datetime(datetime).sum(:capacity)
+  end
+
+  def occupied_tables_at_datetime(datetime)
+    reservations_at_datetime(datetime).pluck('tables.id')
   end
 
   def available_tables_at_datetime(datetime)
-    occupied_table_ids = reservations.where(Reservation.arel_table[:start_datetime].lteq(datetime))
-                                     .where(Reservation.arel_table[:end_datetime].gteq(datetime))
-                                     .joins(reservation_tables: :table )
-                                     .pluck('tables.id')
-
-    tables.pluck(:id) - occupied_table_ids
+    tables.pluck(:id) - occupied_tables_at_datetime(datetime)
   end
 
   def max_availability_within_span(start_datetime, end_datetime)

--- a/spec/requests/table_spec.rb
+++ b/spec/requests/table_spec.rb
@@ -1,24 +1,54 @@
 require 'rails_helper'
 
 describe Resources::Table::API do
-# describe do
-  context 'GET /tables/' do
-    it 'returns all tables' do
-      restaurant = FactoryBot.create(:restaurant)
-      table = FactoryBot.create(:table, restaurant: restaurant)
+  describe "#GET methods"do
+    let!(:restaurant) { FactoryBot.create(:restaurant) }
+    let!(:table) { FactoryBot.create(:table, restaurant: restaurant) }
 
-      get "/tables", as: :json
-      expect(response.body).to eq [::API::Entities::Table.new(table)].to_json
+    context 'GET /tables/' do
+      it 'returns all tables' do
+        get "/tables", as: :json
+        expect(response.body).to eq [::API::Entities::Table.new(table)].to_json
+      end
     end
-  end
 
-  context 'GET /tables/:id' do
-    it 'returns a table' do
-      restaurant = FactoryBot.create(:restaurant)
-      table = FactoryBot.create(:table, restaurant: restaurant)
+    context 'GET /tables/:id' do
+      it 'returns a table' do
+        get "/tables/#{table.id}", as: :json
+        expect(response.body).to eq ::API::Entities::Table.new(table).to_json
+      end
+    end
 
-      get "/tables/#{table.id}", as: :json
-      expect(response.body).to eq ::API::Entities::Table.new(table).to_json
+    context 'GET /tables/occupied/' do
+      let!(:table_2) { FactoryBot.create(:table, restaurant: restaurant, capacity: 4) }
+
+      let!(:reservation) do
+        FactoryBot.create(:reservation,
+                          restaurant: restaurant,
+                          owner_name: 'Previous Tester',
+                          owner_phone_number: '1-777-555-4444',
+                          start_datetime: Time.zone.now + 12.hour,
+                          total_guests: 4)
+      end
+
+      let!(:reservation_table) { FactoryBot.create(:reservation_table, reservation: reservation, table: table_2) }
+
+      let(:params) do
+        {
+          restaurant_id: reservation.restaurant_id,
+          reservation_datetime: reservation.start_datetime
+        }
+      end
+
+
+      it 'returns all occupied tables given a datetime' do
+        # 405 Not Allowed
+        # get "/tables/occupied/", params: params, as: :json
+
+        get "/tables/occupied?restaurant_id=#{params[:restaurant_id]}&reservation_datetime=#{params[:reservation_datetime]}", as: :json
+
+        expect(response.body).to eq [::API::Entities::Table.new(table_2)].to_json
+      end
     end
   end
 end


### PR DESCRIPTION
Reorganize restaurant methods for querying available tables, occupied tables, and guests at datetime. Add get occupied route under tables to pull reserved tables for a restaurant based off reservation datetime.