### PR TITLE
Reorganize seed file to fix a new reservation for every table

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,22 +30,23 @@ initial_datetime = Time.zone.now - 2.weeks
 
 # Seed past and future Reservations
 Restaurant.unscoped.each do |restaurant|
-  restaurant.tables.each do |table|
-    (0..7).each do |day|
-      start_datetime = initial_datetime + day.days
+  (0..7).each do |day|
+    start_datetime = initial_datetime + day.days
 
-      reservation = Reservation.new(
-        restaurant: restaurant,
-        owner_name: 'Previous Tester',
-        owner_phone_number: '1-777-555-4444',
-        start_datetime: start_datetime,
-        end_datetime: start_datetime + 2.hours,
-        total_guests: table.capacity
-      )
+    reservation = Reservation.new(
+      restaurant: restaurant,
+      owner_name: 'Previous Tester',
+      owner_phone_number: '1-777-555-4444',
+      start_datetime: start_datetime,
+      end_datetime: start_datetime + 2.hours,
+      total_guests: restaurant.capacity
+    )
 
+    reservation.save!
+
+    restaurant.tables.each do |table|
       reservation.reservation_tables.build(table: table)
 
-      reservation.save!
       reservation.reservation_tables.each(&:save!)
     end
   end


### PR DESCRIPTION
Every table should have at least one reservation table, but only one reservation for the day seeded.